### PR TITLE
add new unit test to validate convertTo empty.

### DIFF
--- a/src/main/java/com/jalasoft/devfund2/common/constant/ErrorMessageConstant.java
+++ b/src/main/java/com/jalasoft/devfund2/common/constant/ErrorMessageConstant.java
@@ -17,7 +17,7 @@ package com.jalasoft.devfund2.common.constant;
 
 public class ErrorMessageConstant {
 
-    public final static String NOT_NULL_OR_EMPTY_MESSAGE = "% cannot be null or empty.";
+    public final static String NOT_NULL_OR_EMPTY_MESSAGE = "%s cannot be null or empty.";
     public final static String MD5_ERROR_MESSAGE = "Invalid md5.";
     public final static String MULTIPART_ERROR_MESSAGE = "Invalid multipart file.";
     public final static String MIME_TYPE_ERROR_MESSAGE = "Invalid mime type.";

--- a/src/main/java/com/jalasoft/devfund2/model/convert/parameter/ConvertImageParam.java
+++ b/src/main/java/com/jalasoft/devfund2/model/convert/parameter/ConvertImageParam.java
@@ -61,9 +61,9 @@ public class ConvertImageParam extends Parameter{
 
         List<IValidatorStrategy> strategyList = Arrays.asList(
                 new FileValidation(this.inputFile, true),
+                new NotNullOrEmptyValidation("convertTo", this.convertTo),
                 new NotNullOrEmptyValidation("outputDir", this.outputDir),
                 new FileValidation(new File(this.outputDir), false),
-                new NotNullOrEmptyValidation("convertTo", this.convertTo),
                 new ConvertToValidation(this.convertTo)
         );
 

--- a/src/test/java/com/jalasoft/devfund2/model/convert/ConverterImageToPsdTest.java
+++ b/src/test/java/com/jalasoft/devfund2/model/convert/ConverterImageToPsdTest.java
@@ -88,4 +88,16 @@ public class ConverterImageToPsdTest {
         ConverterImageToPsd con = new ConverterImageToPsd();
         con.convert(null);
     }
+
+    @Test(expected =  InvalidDataException.class)
+    public void convertToEmpty() throws InvalidDataException, ConvertException {
+        ConvertImageParam param = new ConvertImageParam(
+                new File(PATH + "tree.jpg"),
+                "",
+                OUTPUT_PATH
+        );
+
+        ConverterImageToPsd con = new ConverterImageToPsd();
+        con.convert(param);
+    }
 }


### PR DESCRIPTION
update constant message foNOT_NULL_OR_EMPTY_MESSAGE constant.
and add a new unit test

When a new test was added to valid empty value for convertTo field, next issue was faced in the NotNullOrEmptyValidation class

string.format Illegal format string specifier: flag ' ' not allowed in '% c'